### PR TITLE
Do not run on msys2 on Windows

### DIFF
--- a/.github/workflows/haskell.yml
+++ b/.github/workflows/haskell.yml
@@ -11,24 +11,12 @@ jobs:
 
     strategy:
       matrix:
-        sys:
-        - { os: ubuntu-latest, shell: bash }
-        - { os: windows-latest, shell: 'msys2 {0}' }
+        os: ['ubuntu-latest', 'windows-latest']
 
-    runs-on: ${{ matrix.sys.os }}
-
-    defaults:
-      run:
-        shell: ${{ matrix.sys.shell }}
+    runs-on: ${{ matrix.os }}
 
     steps:
     - uses: actions/checkout@v2
-
-    - uses: msys2/setup-msys2@v2
-      with:
-        update: true
-        install: base-devel
-      if: runner.os == 'Windows'
 
     - uses: haskell/actions/setup@v1
       id: haskell_setup

--- a/.github/workflows/haskell.yml
+++ b/.github/workflows/haskell.yml
@@ -24,23 +24,6 @@ jobs:
         ghc-version: '8.10.7'
         cabal-version: '3.6.0.0'
 
-    # Adding a path to msys2's PATH on GitHub Actions is pretty troublesome. So I'll output the path to a file.
-    # (See https://github.com/msys2/setup-msys2/issues/98 to how to add a path to PATH.)
-    #
-    # Somehow a configure script can't find grep, so I specify the its path explicitly.
-    # See https://stackoverflow.com/questions/71891129/the-configure-script-cant-find-grep-on-windows-on-github-actions.
-    - name: Store the path to Cabal (Windows)
-      run: |
-        echo "GREP=$(which grep) $(cygpath --unix '${{ steps.haskell_setup.outputs.cabal-exe }}') "'$@ '"-w $(cygpath --unix '${{ steps.haskell_setup.outputs.ghc-exe }}')" > cabal.sh
-        chmod +x cabal.sh
-      if: runner.os == 'Windows'
-
-    - name: Store the path to Cabal (Linux)
-      run: |
-        echo '${{ steps.haskell_setup.outputs.cabal-exe }} $@' > cabal.sh
-        chmod +x cabal.sh
-      if: runner.os == 'Linux'
-
     - name: Cache
       uses: actions/cache@v2
       env:
@@ -54,13 +37,13 @@ jobs:
         restore-keys: ${{ runner.os }}-${{ hashFiles('cabal.project.freeze') }}
 
     - name: Update Cabal
-      run: ./cabal.sh update
+      run: cabal update
 
     - name: Build
-      run: ./cabal.sh build --enable-tests --enable-benchmarks all -j
+      run: cabal build --enable-tests --enable-benchmarks all -j
 
     - name: Run tests
-      run: ./cabal.sh test all -j
+      run: cabal test all -j
 
   format_and_lint:
 


### PR DESCRIPTION
We don't need msys2 because we don't need any extra dependencies. This may be a fix of #4's errors.
